### PR TITLE
Improve usernames

### DIFF
--- a/src/modules/Common/api/searches/[name]/botRepartition.ts
+++ b/src/modules/Common/api/searches/[name]/botRepartition.ts
@@ -1,0 +1,58 @@
+import * as SearchManager from '../../../managers/SearchManager';
+import * as UserManager from '../../../managers/UserManager';
+
+import { CommonGetFilters, GetSearchBotRepartitionResponse } from 'modules/Common/interfaces';
+// Next.js API route support: https://nextjs.org/docs/api-routes/introduction
+import type { NextApiRequest, NextApiResponse } from 'next';
+
+import HttpStatusCode from 'http-status-codes';
+import { withAuth } from 'modules/Auth';
+import { withDb } from 'utils/db';
+
+const get =
+  (filter: CommonGetFilters) => async (res: NextApiResponse<GetSearchBotRepartitionResponse>) => {
+    try {
+      const search = await SearchManager.get({ name: filter.name });
+
+      if (!search) {
+        res.statusCode = HttpStatusCode.NOT_FOUND;
+        res.json({ status: 'ko', message: 'Search was not found' });
+        return;
+      }
+      const { repartition, count } = await UserManager.getBotRepartition({
+        searchIds: [search._id],
+        startDate: filter.min,
+        endDate: filter.max,
+        lang: filter.lang,
+        username: filter.username,
+        hashtag: filter.hashtag,
+        content: filter.content,
+      });
+
+      if (filter.min && filter.max) {
+        res.setHeader('Cache-Control', `max-age=${10 * 60}`);
+      }
+      res.statusCode = HttpStatusCode.OK;
+      res.json({
+        status: 'ok',
+        message: 'Search BotRepartition details',
+        repartition,
+        count,
+      });
+      return res;
+    } catch (e: any) {
+      res.statusCode = HttpStatusCode.METHOD_FAILURE;
+      res.json({ status: 'ko', message: e.toString() });
+    }
+  };
+
+const search = async (req: NextApiRequest, res: NextApiResponse) => {
+  if (req.method === 'GET' && req.query.name) {
+    return get(req.query as any)(res);
+  }
+
+  res.statusCode = HttpStatusCode.FORBIDDEN;
+  res.json({ status: 'ko', message: 'Nothing there' });
+};
+
+export default withAuth(withDb(search));

--- a/src/modules/Common/api/searches/[name]/nbTweetsRepartition.ts
+++ b/src/modules/Common/api/searches/[name]/nbTweetsRepartition.ts
@@ -1,0 +1,58 @@
+import * as SearchManager from '../../../managers/SearchManager';
+
+import { CommonGetFilters, GetSearchNbTweetsRepartitionResponse } from 'modules/Common/interfaces';
+// Next.js API route support: https://nextjs.org/docs/api-routes/introduction
+import type { NextApiRequest, NextApiResponse } from 'next';
+
+import HttpStatusCode from 'http-status-codes';
+import { withAuth } from 'modules/Auth';
+import { withDb } from 'utils/db';
+
+const get =
+  (filter: CommonGetFilters) =>
+  async (res: NextApiResponse<GetSearchNbTweetsRepartitionResponse>) => {
+    try {
+      const search = await SearchManager.get({ name: filter.name });
+
+      if (!search) {
+        res.statusCode = HttpStatusCode.NOT_FOUND;
+        res.json({ status: 'ko', message: 'Search was not found' });
+        return;
+      }
+      const { repartition, count } = await SearchManager.getNbTweetsRepartition({
+        searchIds: [search._id],
+        startDate: filter.min,
+        endDate: filter.max,
+        lang: filter.lang,
+        username: filter.username,
+        hashtag: filter.hashtag,
+        content: filter.content,
+      });
+
+      if (filter.min && filter.max) {
+        res.setHeader('Cache-Control', `max-age=${10 * 60}`);
+      }
+      res.statusCode = HttpStatusCode.OK;
+      res.json({
+        status: 'ok',
+        message: 'Search NbTweetsRepartition details',
+        repartition,
+        count,
+      });
+      return res;
+    } catch (e: any) {
+      res.statusCode = HttpStatusCode.METHOD_FAILURE;
+      res.json({ status: 'ko', message: e.toString() });
+    }
+  };
+
+const search = async (req: NextApiRequest, res: NextApiResponse) => {
+  if (req.method === 'GET' && req.query.name) {
+    return get(req.query as any)(res);
+  }
+
+  res.statusCode = HttpStatusCode.FORBIDDEN;
+  res.json({ status: 'ko', message: 'Nothing there' });
+};
+
+export default withAuth(withDb(search));

--- a/src/modules/Common/components/Datatables/UsernameTable.d.ts
+++ b/src/modules/Common/components/Datatables/UsernameTable.d.ts
@@ -2,6 +2,7 @@ export interface UsernameTableProps {
   exportName: string;
   data: Username[];
   nbData?: number;
+  nbPerPage?: number;
   onUsernameClick: (username: string) => any;
   onUsernameViewClick: (username: string) => any;
   onUsernameSearchClick: (username: string) => any;

--- a/src/modules/Common/components/Datatables/UsernameTable.tsx
+++ b/src/modules/Common/components/Datatables/UsernameTable.tsx
@@ -18,6 +18,7 @@ const UsernameTable = ({
   onUsernameSearchClick,
   onUsernameFilterClick,
   nbData,
+  nbPerPage,
 }: UsernameTableProps) => {
   const columns = [
     {
@@ -157,6 +158,16 @@ const UsernameTable = ({
     },
   ];
 
+  const nbUsernames = nbData || data.length;
+  const additionalInfo =
+    nbPerPage && nbUsernames > nbPerPage ? (
+      <>
+        <br />
+        <small> ℹ Only the first {nbPerPage} are listed here</small>
+      </>
+    ) : (
+      ''
+    );
   return (
     <Table<Username>
       title={`Active users`}
@@ -164,7 +175,7 @@ const UsernameTable = ({
         <>
           <strong>{(nbData || data.length).toLocaleString('en')}</strong> users listed by number of
           use - <strong>{data.filter((user) => user.verified).length.toLocaleString('en')}</strong>{' '}
-          verified users
+          verified users{additionalInfo}
         </>
       }
       columns={columns}

--- a/src/modules/Common/data-components/BotRepartition.tsx
+++ b/src/modules/Common/data-components/BotRepartition.tsx
@@ -1,0 +1,58 @@
+import * as React from 'react';
+
+import Alert from '../components/Alert/Alert';
+import BarGraph from '../components/Charts/BarGraph';
+import { GetSearchBotRepartitionResponse } from '../interfaces';
+import Loading from 'components/Loading';
+import useSWR from 'swr';
+
+interface BotRepartitionProps {
+  search: string;
+  refreshInterval: number;
+  queryParamsStringified?: string;
+}
+
+const BotRepartition = ({
+  search,
+  refreshInterval,
+  queryParamsStringified = '',
+}: BotRepartitionProps) => {
+  const { data, isValidating } = useSWR<GetSearchBotRepartitionResponse>(
+    `/api/searches/${encodeURIComponent(search)}/botRepartition${queryParamsStringified}`,
+    {
+      refreshInterval,
+      revalidateOnMount: true,
+      revalidateOnFocus: false,
+    }
+  );
+  if (isValidating && !data) {
+    return <Loading message="Loading..." />;
+  }
+
+  const repartition = data?.repartition || [];
+  const nbUsernames = data?.count || 0;
+  if (nbUsernames === 0) {
+    return (
+      <Alert size="small" type="info">
+        No users found.
+      </Alert>
+    );
+  }
+
+  return (
+    <BarGraph
+      title="Bot probability"
+      subtitle="In number of users, views on bar chart"
+      yAxisTitle="Nb of users"
+      data={repartition.map((value: number, index: number) => ({
+        x: index,
+        y: value,
+      }))}
+      xAxis={{
+        categories: [...Array(repartition.length)].map((_, index) => `${index}%`),
+      }}
+    />
+  );
+};
+
+export default React.memo(BotRepartition);

--- a/src/modules/Common/data-components/NbTweetsRepartition.tsx
+++ b/src/modules/Common/data-components/NbTweetsRepartition.tsx
@@ -1,0 +1,62 @@
+import * as React from 'react';
+
+import Alert from '../components/Alert/Alert';
+import BarGraph from '../components/Charts/BarGraph';
+import { GetSearchNbTweetsRepartitionResponse } from '../interfaces';
+import Loading from 'components/Loading';
+import useSWR from 'swr';
+
+interface NbTweetsRepartitionProps {
+  search: string;
+  refreshInterval: number;
+  queryParamsStringified?: string;
+}
+
+const NbTweetsRepartition = ({
+  search,
+  refreshInterval,
+  queryParamsStringified = '',
+}: NbTweetsRepartitionProps) => {
+  const { data, isValidating } = useSWR<GetSearchNbTweetsRepartitionResponse>(
+    `/api/searches/${encodeURIComponent(search)}/nbTweetsRepartition${queryParamsStringified}`,
+    {
+      refreshInterval,
+      revalidateOnMount: true,
+      revalidateOnFocus: false,
+    }
+  );
+  if (isValidating || !data) {
+    return <Loading message="Loading..." />;
+  }
+  const repartition = data?.repartition || {};
+  const nbUsernames = data?.count || 0;
+  if (nbUsernames === 0) {
+    return (
+      <Alert size="small" type="info">
+        No users found.
+      </Alert>
+    );
+  }
+
+  return (
+    <BarGraph
+      title="Tweets per user"
+      subtitle="Views on bar chart"
+      yAxisTitle="Nb of users"
+      xAxis={{
+        categories: Object.keys(repartition),
+      }}
+      data={Object.entries(repartition).map(([_, y]: [string, unknown], index) => ({
+        x: index,
+        y: y as number,
+      }))}
+      plotOptions={{
+        series: {
+          minPointLength: 3,
+        },
+      }}
+    />
+  );
+};
+
+export default React.memo(NbTweetsRepartition);

--- a/src/modules/Common/data-components/Username.tsx
+++ b/src/modules/Common/data-components/Username.tsx
@@ -41,7 +41,9 @@ const DataUsername = ({
     return <Loading message="Loading..." />;
   }
   const usernames = data?.usernames || [];
-  if (usernames.length === 0) {
+  const nbUsernames = data?.count || 0;
+  const nbPerPage = data?.nbPerPage;
+  if (nbUsernames === 0) {
     return (
       <Alert size="small" type="info">
         No users found.
@@ -97,7 +99,8 @@ const DataUsername = ({
   return (
     <div className="fr-col">
       <UsernameTable
-        nbData={usernames.length}
+        nbData={nbUsernames}
+        nbPerPage={nbPerPage}
         data={usernames}
         onUsernameClick={onUsernameClick}
         onUsernameViewClick={onUsernameViewClick}

--- a/src/modules/Common/data-components/Username.tsx
+++ b/src/modules/Common/data-components/Username.tsx
@@ -64,38 +64,6 @@ const DataUsername = ({
     [...Array(100)].map(() => 0)
   );
 
-  // const { max: maxTweetsPerUser } = usernames.reduce(
-  //   (acc, user) => ({ min: Math.min(acc.min, user.value), max: Math.max(acc.max, user.value) }),
-  //   { min: Infinity, max: -1 }
-  // );
-
-  const nbTweetsPerUserRepartition: any = usernames.reduce(
-    (repartition, { value }) => {
-      if (value === 1) {
-        repartition['1']++;
-      } else if (value >= 2 && value <= 5) {
-        repartition['2-5']++;
-      } else if (value >= 6 && value <= 10) {
-        repartition['6-10']++;
-      } else if (value >= 11 && value <= 50) {
-        repartition['11-50']++;
-      } else if (value >= 50 && value <= 200) {
-        repartition['50-200']++;
-      } else if (value > 200) {
-        repartition['200+']++;
-      }
-      return repartition;
-    },
-    {
-      '1': 0,
-      '2-5': 0,
-      '6-10': 0,
-      '11-50': 0,
-      '50-200': 0,
-      '200+': 0,
-    }
-  );
-
   return (
     <div className="fr-col">
       <UsernameTable
@@ -122,38 +90,6 @@ const DataUsername = ({
           }}
         />
       </div>
-      <div className="fr-mt-8w">
-        <BarGraph
-          title="Tweets per user"
-          subtitle="Views on bar chart"
-          yAxisTitle="Nb of users"
-          xAxis={{
-            categories: Object.keys(nbTweetsPerUserRepartition),
-          }}
-          data={Object.entries(nbTweetsPerUserRepartition).map(
-            ([_, y]: [string, unknown], index) => ({
-              x: index,
-              y: y as number,
-            })
-          )}
-          plotOptions={{
-            series: {
-              minPointLength: 3,
-            },
-          }}
-        />
-      </div>
-      {/* <div className="fr-mt-8w">
-        <PieChart
-          title="Proportion of deleted and suspended account"
-          subTitle="Lorem ipssum"
-          data={[
-            { id: 'active', label: 'Active', value: 80 },
-            { id: 'suspened', label: 'Suspended', value: 4 },
-            { id: 'deleted', label: 'Deleted', value: 16 },
-          ]}
-        />
-      </div> */}
     </div>
   );
 };

--- a/src/modules/Common/data-components/Username.tsx
+++ b/src/modules/Common/data-components/Username.tsx
@@ -1,7 +1,6 @@
 import * as React from 'react';
 
 import Alert from '../components/Alert/Alert';
-import BarGraph from '../components/Charts/BarGraph';
 import { GetSearchUsernamesResponse } from '../interfaces';
 import Loading from 'components/Loading';
 import UsernameTable from '../components/Datatables/UsernameTable';
@@ -51,19 +50,6 @@ const DataUsername = ({
     );
   }
 
-  const botRepartition: any = usernames.reduce(
-    (repartition, user) => {
-      if (!user || !user.botScore) {
-        return repartition;
-      }
-      const value = Math.round(user.botScore * 100);
-      repartition[value]++;
-      return repartition;
-    },
-
-    [...Array(100)].map(() => 0)
-  );
-
   return (
     <div className="fr-col">
       <UsernameTable
@@ -76,20 +62,6 @@ const DataUsername = ({
         onUsernameFilterClick={onUsernameFilterClick}
         exportName={exportName}
       />
-      <div className="fr-mt-8w">
-        <BarGraph
-          title="Bot probability"
-          subtitle="In number of users, views on bar chart"
-          yAxisTitle="Nb of users"
-          data={botRepartition.map((value: number, index: number) => ({
-            x: index,
-            y: value,
-          }))}
-          xAxis={{
-            categories: [...Array(botRepartition.length)].map((_, index) => `${index}%`),
-          }}
-        />
-      </div>
     </div>
   );
 };

--- a/src/modules/Common/interfaces/index.ts
+++ b/src/modules/Common/interfaces/index.ts
@@ -125,6 +125,8 @@ export interface GetSearchHashtagsResponse extends CommonResponse {
  ******************************************/
 export interface GetSearchUsernamesResponse extends CommonResponse {
   usernames?: UsernameTableProps['data'];
+  count?: number;
+  nbPerPage?: number;
 }
 
 /******************************************

--- a/src/modules/Common/interfaces/index.ts
+++ b/src/modules/Common/interfaces/index.ts
@@ -139,6 +139,10 @@ export interface GetSearchNbTweetsRepartitionResponse extends CommonResponse {
   };
   count?: number;
 }
+export interface GetSearchBotRepartitionResponse extends CommonResponse {
+  repartition?: number[];
+  count?: number;
+}
 
 /******************************************
  * Tweets

--- a/src/modules/Common/interfaces/index.ts
+++ b/src/modules/Common/interfaces/index.ts
@@ -128,6 +128,17 @@ export interface GetSearchUsernamesResponse extends CommonResponse {
   count?: number;
   nbPerPage?: number;
 }
+export interface GetSearchNbTweetsRepartitionResponse extends CommonResponse {
+  repartition?: {
+    '1': number;
+    '2-5': number;
+    '6-10': number;
+    '11-50': number;
+    '50-200': number;
+    '200+': number;
+  };
+  count?: number;
+}
 
 /******************************************
  * Tweets

--- a/src/modules/Common/managers/SearchManager.tsx
+++ b/src/modules/Common/managers/SearchManager.tsx
@@ -469,6 +469,25 @@ export const getNbTweetsRepartition = async (filters: SearchFilter) => {
   };
 };
 
+export const getUsernamesValues = async (filters: SearchFilter) => {
+  const match: any = getMatch(filters);
+  const aggregation = [
+    {
+      $match: match,
+    },
+    { $group: { _id: null, usernames: { $addToSet: '$username' } } },
+    { $project: { _id: 0, usernames: true } },
+  ];
+
+  const [{ usernames }] = await TweetModel.aggregate<{ usernames: string[] }>(
+    aggregation
+  ).allowDiskUse(true);
+
+  console.timeEnd(timer);
+
+  return usernames;
+};
+
 // Get Photos
 export const getPhotos = async (filters: SearchFilter) => {
   const match: any = getMatch(filters);

--- a/src/modules/Common/pages/searches/[search].tsx
+++ b/src/modules/Common/pages/searches/[search].tsx
@@ -39,6 +39,10 @@ const ssrConfig = {
 const LanguageData = dynamic(() => import('../../data-components/Language'), ssrConfig);
 const HashtagData = dynamic(() => import('../../data-components/Hashtag'), ssrConfig);
 const UsernameData = dynamic(() => import('../../data-components/Username'), ssrConfig);
+const NbTweetsRepartition = dynamic(
+  () => import('../../data-components/NbTweetsRepartition'),
+  ssrConfig
+);
 const VolumetryGraph = dynamic(() => import('../../components/Charts/VolumetryGraph'), ssrConfig);
 const TweetsData = dynamic(() => import('../../data-components/Tweets'), ssrConfig);
 const VideosData = dynamic(() => import('../../data-components/Videos'), ssrConfig);
@@ -664,6 +668,13 @@ const SearchPage = ({
                     'YYYYMMDDHH'
                   )}__${searchName}__associated-usernames`}
                 />
+                <div className="fr-mt-8w">
+                  <NbTweetsRepartition
+                    search={searchName}
+                    refreshInterval={refreshInterval}
+                    queryParamsStringified={queryParamsStringified}
+                  />
+                </div>
               </TabPanel>
 
               <TabPanel>

--- a/src/modules/Common/pages/searches/[search].tsx
+++ b/src/modules/Common/pages/searches/[search].tsx
@@ -43,6 +43,7 @@ const NbTweetsRepartition = dynamic(
   () => import('../../data-components/NbTweetsRepartition'),
   ssrConfig
 );
+const BotRepartition = dynamic(() => import('../../data-components/BotRepartition'), ssrConfig);
 const VolumetryGraph = dynamic(() => import('../../components/Charts/VolumetryGraph'), ssrConfig);
 const TweetsData = dynamic(() => import('../../data-components/Tweets'), ssrConfig);
 const VideosData = dynamic(() => import('../../data-components/Videos'), ssrConfig);
@@ -670,6 +671,13 @@ const SearchPage = ({
                 />
                 <div className="fr-mt-8w">
                   <NbTweetsRepartition
+                    search={searchName}
+                    refreshInterval={refreshInterval}
+                    queryParamsStringified={queryParamsStringified}
+                  />
+                </div>
+                <div className="fr-mt-8w">
+                  <BotRepartition
                     search={searchName}
                     refreshInterval={refreshInterval}
                     queryParamsStringified={queryParamsStringified}

--- a/src/pages/api/searches/[name]/botRepartition.ts
+++ b/src/pages/api/searches/[name]/botRepartition.ts
@@ -1,0 +1,1 @@
+export { default } from 'modules/Common/api/searches/[name]/botRepartition';

--- a/src/pages/api/searches/[name]/nbTweetsRepartition.ts
+++ b/src/pages/api/searches/[name]/nbTweetsRepartition.ts
@@ -1,0 +1,1 @@
+export { default } from 'modules/Common/api/searches/[name]/nbTweetsRepartition';


### PR DESCRIPTION
As the request for the user table can be very long on some searches let's
- display only the 1000 first
- rewrite bot repartition so that its calculation is now separated
- rewrite nb tweets repartition so that its calculation is now separated

A new major improvment could be to actually store directly in the `users` collection, the `searches` associated.
I will try to do this in a near future
